### PR TITLE
Only use countryInfo data when needed.

### DIFF
--- a/src/services/RedirectService.php
+++ b/src/services/RedirectService.php
@@ -81,8 +81,9 @@ class RedirectService extends Component
         }
         
         $countryInfo = GeoMate::$plugin->geo->getCountryInfo($ip);
+        $needsCountryInfo = !in_array($settings->redirectMapSimpleModeKey, ['language', 'languageRegion']);
 
-        if ($countryInfo === null) {
+        if ($countryInfo === null && $needsCountryInfo) {
             GeoMate::log('IP `'.$ip.'` was not found in country database.', Logger::LEVEL_WARNING);
             return null;
         }


### PR DESCRIPTION
Currently, the redirect logic returns null when there is no country info from the database, also when the redirectMapSimpleKey is set to a value that doesn't need that info.

This PR also checks if the request needs country info before returning null.

