### PR TITLE
Prevent duplication of the redirectOverrideParam when switching language more than once on the same page.

### DIFF
--- a/src/services/RedirectService.php
+++ b/src/services/RedirectService.php
@@ -151,7 +151,7 @@ class RedirectService extends Component
         $params = [];
         parse_str($queryString, $params);
 
-        if (isset($params[$settings->redirectOverrideParam] && $params[$settings->redirectOverrideParam] === $settings->paramValue) ) {
+        if (isset($params[$settings->redirectOverrideParam]) && $params[$settings->redirectOverrideParam] === $settings->paramValue) {
             return $val;
         }
 

--- a/src/services/RedirectService.php
+++ b/src/services/RedirectService.php
@@ -146,6 +146,15 @@ class RedirectService extends Component
     {
         /** @var Settings $settings */
         $settings = GeoMate::$plugin->getSettings();
+        
+        $queryString = parse_url($val, PHP_URL_QUERY);
+        $params = [];
+        parse_str($queryString, $params);
+
+        if (isset($params[$settings->redirectOverrideParam] && $params[$settings->redirectOverrideParam] === $settings->paramValue) ) {
+            return $val;
+        }
+
         return GeoMateHelper::addUrlParam($val, $settings->redirectOverrideParam, $settings->paramValue);
     }
 


### PR DESCRIPTION
Right now redirectOverrideParam will be added to the url every time the user changes sites while on the same page.

This pull request adds a check to the addOverrideParam in the RedirectService to prevent the url from getting cluttered with params.

